### PR TITLE
修复事件的不连续导致的自动滚动

### DIFF
--- a/xrecyclerview/src/main/java/com/jcodecraeer/xrecyclerview/XRecyclerView.java
+++ b/xrecyclerview/src/main/java/com/jcodecraeer/xrecyclerview/XRecyclerView.java
@@ -402,6 +402,10 @@ public class XRecyclerView extends RecyclerView {
                         break;
                     mRefreshHeader.onMove(deltaY / DRAG_RATE);
                     if (mRefreshHeader.getVisibleHeight() > 0 && mRefreshHeader.getState() < ArrowRefreshHeader.STATE_REFRESHING) {
+                        MotionEvent event = MotionEvent.obtain(ev);
+                        event.setAction(MotionEvent.ACTION_DOWN);
+                        super.onTouchEvent(event);
+                        event.recycle();
                         return false;
                     }
                 }


### PR DESCRIPTION
当RefreshHeader开始下拉时，父类`RecyclerView`接收到`ACTION_DOWN`事件，可以记录位置到`mLastTouchY`。但是在下拉过程中`RecyclerView`收不到`ACTION_MOVE`事件，无法记录最后位置。当手动把RefreshHeader推回去时，`RecyclerView`又开始可以接收到`ACTION_MOVE`事件，但是此时的指针位置和开始下拉时的位置`mLastTouchY`不相同，差值时大时小，所以这个`ACTION_MOVE`事件将会导致一定幅度的自动滚动。

为了使`mLastTouchY`不出现断点，在RefreshHeader下拉过程中，同时也要更新`mLastTouchY`的值。解决方法是从原事件复制出一个新事件，并修改为`ACTION_DOWN`事件，然后传递给父类即可更新`mLastTouchY`。