### PR TITLE
commit: 修复内存泄露问题

### DIFF
--- a/xrecyclerview/src/main/java/com/jcodecraeer/xrecyclerview/progressindicator/indicator/BaseIndicatorController.java
+++ b/xrecyclerview/src/main/java/com/jcodecraeer/xrecyclerview/progressindicator/indicator/BaseIndicatorController.java
@@ -104,14 +104,10 @@ public abstract class BaseIndicatorController {
                     }
                     break;
                 case END:
-                    if (isRunning){
-                        animator.end();
-                    }
+                    animator.end();
                     break;
                 case CANCEL:
-                    if (isRunning){
-                        animator.cancel();
-                    }
+                    animator.cancel();
                     break;
             }
         }


### PR DESCRIPTION
由于使用了延时执行的属性动画，且每个属性动画引用被ThreadLocal所持有。如果刷新足够快，就会出席那动画还没来得及执行就已结束。这时如果依然判断是否为running才去end或者cancel，会出现尚未执行的动画不会被end和cancel，从而导致内存泄露